### PR TITLE
Add support for myUplink

### DIFF
--- a/config/nibe.cfg
+++ b/config/nibe.cfg
@@ -5,5 +5,5 @@
 
 [Section]
 nibe_api_client_secret=" "
-redirect_url="http://loxberry.fritz.box/plugins/nibeuplink/index.php"
+redirect_url="http://loxberry/plugins/nibeuplink"
 nibe_api_client_id=" "

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -10,7 +10,7 @@ EMAIL=info@siedhof.de
 [PLUGIN]
 # The version of your plugin - important if you would like to write an
 # upgrade script.
-VERSION=0.0.2
+VERSION=2.0.0
 
 # Short name and prefered subfolder of your Plugin (do not use blanks - they
 # will be filtered - and use lowercase only)! Used for script names in

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -64,7 +64,7 @@ LB_MINIMUM=1.0.0
 LB_MAXIMUM=false
 
 # If your plugin runs only on a special architecture (e.g. if you use the GPIOs
-# on a Raspberry platform), please set the architecture here. You can seperate
+# on a Raspberry platform), please set the architecture here. You can separate
 # different architectures with a comma. Set to false or leave it empty if your
 # plugin do not use any special features of an architecture.
 #

--- a/templates/config.html
+++ b/templates/config.html
@@ -1,11 +1,10 @@
-<div role=\ "main\" class=\ "ui-content\">
-        <div class=\ "ui-body ui-body-a ui-corner-all loxberry-logo\">
-                <div style=\ "margin: 5%;\">
+<div role="main" class="ui-content">
+        <div class="ui-body ui-body-a ui-corner-all loxberry-logo">
+                <div style="margin: 5%;">
 
-
-                        <h2>Einstellungen</h2>
-                        <p>Nach dem Erstellen der Nibe Uplink Applikation stehen müssen die folgenden Informationen von der
-                                Webseite übernommen werden</p>
+                        <h2>Settings</h2>
+                        <p>After creating the Nibe Uplink application, the following information must be copied from the
+                                website</p>
                         <form method="post" data-ajax="false" name="main_form" id="main_form" action="./saveConfig.cgi">
                                 <input type="hidden" id="lang" name="lang" value="<!--$lang-->">
                                 <div class="form-group">
@@ -46,7 +45,7 @@
                                                 <tr>
                                                         <td width="25%">&nbsp</td>
                                                         <td width="50%" colspan="2">
-                                                                <input id="submit" name="submit" type="submit" value="Speichern">
+                                                                <input id="submit" name="submit" type="submit" value="Save">
                                                         </td>
                                                         <td width="25%">
                                                                 &nbsp

--- a/templates/config.html
+++ b/templates/config.html
@@ -61,6 +61,21 @@
                                         </table>
                                 </div>
                         </form>
+                        <script>
+                                // Trim inputs on blur
+                                document.querySelectorAll('.textfield').forEach(input => {
+                                    input.addEventListener('blur', function() {
+                                        this.value = this.value.trim();
+                                    });
+                                });
+
+                                // Ensure trimmed values on form submit
+                                document.getElementById('main_form').addEventListener('submit', function(e) {
+                                    document.querySelectorAll('.textfield').forEach(input => {
+                                        input.value = input.value.trim();
+                                    });
+                                });
+                        </script>
                 </div>
         </div>
 </div>

--- a/webfrontend/html/class.nibeGateway.php
+++ b/webfrontend/html/class.nibeGateway.php
@@ -182,7 +182,7 @@ class NibeGateway {
 			$URL = $this->nibeAPI->authorizationURL();
 
 			echo "You're not authorized yet.<br /><br />\n";
-			echo "<b>Important:</b> If you haven't done that yet, create an application on <a href=\"https://api.myuplink.com\">https://api.myuplink.com</a> first and update the config section in the index.php (this file).<br ><br />\n";
+			echo "<b>Important:</b> If you haven't done that yet, create an application on <a href=\"https://api.myuplink.com\">https://api.myuplink.com</a> first and update the <a href=\"/admin/plugins/nibeuplink/config.cgi	\">config section</a>.<br ><br />\n";
 			echo "If you think you're ready to connect this bridge to the MyUplink API, click <a href=\"$URL\">here</a>.";
 			die();
 		}

--- a/webfrontend/html/index.php
+++ b/webfrontend/html/index.php
@@ -29,7 +29,7 @@ if ($nibeAPI->debugActive)
 
 if (empty($_GET)) {
     // The Navigation Bar
-	$navbar[1]['Name'] = "Einstellungen";
+	$navbar[1]['Name'] = "Settings";
 	$navbar[1]['URL'] = 'config.cgi';
 	$navbar[2]['Name'] = "Nibe API";
 	$navbar[2]['URL'] = 'index.php';

--- a/webfrontend/htmlauth/config.cgi
+++ b/webfrontend/htmlauth/config.cgi
@@ -11,7 +11,7 @@ use strict;
 
 #define vavigation
 our %navbar;
-$navbar{1}{Name} = "Einstellungen";
+$navbar{1}{Name} = "Settings";
 $navbar{1}{URL} = 'config.cgi';
 $navbar{1}{active} = 1;
 

--- a/webfrontend/htmlauth/saveConfig.cgi
+++ b/webfrontend/htmlauth/saveConfig.cgi
@@ -28,7 +28,7 @@ $pcfg->param('Section.redirect_url', $form{redirect_url});
 $pcfg->save();
 
 our %navbar;
-$navbar{1}{Name} = "Einstellungen";
+$navbar{1}{Name} = "Settings";
 $navbar{1}{URL} = 'config.cgi';
 $navbar{1}{active} = 1;
  


### PR DESCRIPTION
I'm not a PHP developer so I've mostly done this with Cursor. It works with my heat pump but I did have to change some things in the Loxone Config. For example:

Most importantly, with this new myUplink API it's no longer possible to add a thermostat and override Nibe's own indoor thermostat :(

Next, the return format of values changed (I think) so I added a simplified return `format=loxone` like so:
`http://loxberry/plugins/nibeuplink/index.php?mode=raw&format=loxone&exec=devices%2Femmy-r-187737-20250211-06527221231033-68-27-19-36-3a-61%2Fpoints`

Speaking of that URL, the URL has also changed and the Device ID is this really long thing, which can be seen from doing a `systems/me` call. Do pay attention that there are two types of identifiers! The one in the above URL and a normal UUID (which is what you need if you make Normal / Away / Vacation calls).

When you request parameters with the aforementioned URL, you can match the variables like this: `"parameterId": 40022\i"value":\i\v` (make sure that you remove the value adjustment and just change the `Input Value 2` and `Target Value 2` back to 100)

There is no speicifc call for HotWaterBoost anymore, but you can set it like this `/plugins/nibeuplink/?mode=raw&format=json&patch=devices/emmy-r-187737-20250211-06527221231033-68-27-19-36-3a-61/points&data={"48132":"3"}`

You can see the options with this call:

`plugins/nibeuplink/index.php?mode=raw&format=pretty&exec=devices%2Femmy-r-187737-20250211-06527221231033-68-27-19-36-3a-61%2Fpoints?parameters=48132`

You can change the SmartHomeMode with these calls:
/plugins/nibeuplink/?mode=set&systemId=f1ee279f-458c-4d46-a68c-12dbf29ea8da&smartHomeMode=<v>

where v is either `Away`, `Vacation` or `Normal`

I was planning to also make the plugin translatable (hence I changed the strings to English) but I will keep that for a separate PR